### PR TITLE
unify go version to 1.15.5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15.5
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15.5
       id: go
 
     - name: Check out code into the Go module directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -172,7 +172,7 @@ clone_depth: 1
 
 # scripts that run after cloning repository
 install:
-    - export GOVERSION=1.15.2
+    - export GOVERSION=1.15.5
     - wget "https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz"
     - tar xzf "go$GOVERSION.linux-amd64.tar.gz"
     - export GOROOT=$(pwd)/go

--- a/dlredirector/go.mod
+++ b/dlredirector/go.mod
@@ -1,6 +1,6 @@
 module github.com/missdeer/coredns_custom_build/dlredirector
 
-go 1.14
+go 1.15.5
 
 require (
 	github.com/gin-gonic/gin v1.6.3


### PR DESCRIPTION
Currently, the project contains multiple go versions.
Let's try to align them all to the 1.15.5.

For we build and compile in multiple platform, I prefer to have a `.z`(aka. .5) golang version to make it more consistent.
